### PR TITLE
Fix bug with tiered upgrades

### DIFF
--- a/main.js
+++ b/main.js
@@ -275,7 +275,7 @@ var BestDealHelper = {
             let tierChainAmount = me.amount;
             let tierWaitTime = (simWaitTime + simCost / Game.cookiesPs);
             let tierCps = Game.cookiesPs;
-            let tierCpsAcceleration = (Game.cookiesPs - oldCps) / me.BestWaitTime;
+            let tierCpsAcceleration = (Game.cookiesPs - oldCps) / tierWaitTime;
             // Evaluate CpsAcc with more buildings after TierUpgrade
             while (true) {
                 [simCookies, simWaitTime, simCost] = BestDealHelper.calcCookieTimesCost(me.getPrice(), Game.cookiesPs, simCookies, simWaitTime, simCost);


### PR DESCRIPTION
This kept causing the deal helper to recommend buying up to tier thresholds when you really shouldn't, since it ends up using the wait time to buy a single building.